### PR TITLE
Use latest web client and neuro-san to get CORS updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Neuro SAN
 leaf-common==1.2.21
 leaf-server-common==0.1.18
-neuro-san==0.5.19
-neuro-san-web-client==0.1.8
+neuro-san==0.5.20
+neuro-san-web-client==0.1.9
 nsflow==0.5.9
 
 # For the airline_policy demo and agentic rag, to extract text from documents

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Neuro SAN
 leaf-common==1.2.21
 leaf-server-common==0.1.18
-neuro-san==0.5.15
-neuro-san-web-client==0.1.7
+neuro-san==0.5.19
+neuro-san-web-client==0.1.8
 nsflow==0.5.9
 
 # For the airline_policy demo and agentic rag, to extract text from documents


### PR DESCRIPTION
In order to get the CORS fix to neuro-san-demos, we had to update dependencies for both neuro-san and the web client. This PR accomplishes that goal.