### PR TITLE
Upgrade neuro-san and neuro-san-web-client

### DIFF
--- a/coded_tools/music_nerd_pro/accounting.py
+++ b/coded_tools/music_nerd_pro/accounting.py
@@ -39,7 +39,7 @@ class Accountant(CodedTool):
         running_cost: float = float(args.get("running_cost"))
 
         # Increment the running cost
-        updated_running_cost: float = running_cost + 1.0
+        updated_running_cost: float = running_cost + 3.0
 
         tool_response = {"running_cost": updated_running_cost}
         print("-----------------------")

--- a/coded_tools/music_nerd_pro_local/accounting.py
+++ b/coded_tools/music_nerd_pro_local/accounting.py
@@ -39,7 +39,7 @@ class Accountant(CodedTool):
         running_cost: float = float(args.get("running_cost"))
 
         # Increment the running cost
-        updated_running_cost: float = running_cost + 1.0
+        updated_running_cost: float = running_cost + 3.0
 
         tool_response = {"running_cost": updated_running_cost}
         print("-----------------------")

--- a/coded_tools/music_nerd_pro_sly/accounting.py
+++ b/coded_tools/music_nerd_pro_sly/accounting.py
@@ -41,7 +41,7 @@ class AccountantSly(CodedTool):
         running_cost: float = float(sly_data.get("running_cost", 0.0))
 
         # Increment the running cost
-        updated_running_cost: float = running_cost + 1.0
+        updated_running_cost: float = running_cost + 3.0
 
         # Update the sly_data
         sly_data["running_cost"] = updated_running_cost

--- a/coded_tools/music_nerd_pro_sly_local/accounting.py
+++ b/coded_tools/music_nerd_pro_sly_local/accounting.py
@@ -41,7 +41,7 @@ class AccountantSly(CodedTool):
         running_cost: float = float(sly_data.get("running_cost", 0.0))
 
         # Increment the running cost
-        updated_running_cost: float = running_cost + 1.0
+        updated_running_cost: float = running_cost + 3.0
 
         # Update the sly_data
         sly_data["running_cost"] = updated_running_cost

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
 neuro-san==0.5.22
-neuro-san-web-client==0.1.9
+neuro-san-web-client==0.1.10
 nsflow==0.5.9
 
 # For the airline_policy demo and agentic rag, to extract text from documents

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 # Neuro SAN
-leaf-common==1.2.21
-leaf-server-common==0.1.18
-neuro-san==0.5.20
+neuro-san==0.5.22
 neuro-san-web-client==0.1.9
 nsflow==0.5.9
 


### PR DESCRIPTION
Upgraded:
- neuro-san to 0.5.22
- neuro-san-web-client to 0.1.10
And made the Music Nerd cost calculation less easy for LLMs to guess without calling the tool.