### PR TITLE
Use nsflow client as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ activate: ## Activate the venv
 	fi
 
 lint: ## Run code formatting and linting tools on source
-	@if [ "$$(which python | grep -c "./venv")" -eq 0 ]; then \
+	@if [ -z "$$VIRTUAL_ENV" ]; then \
 		echo ""; \
-		echo "Error: Linting must be run using the ./venv Python environment"; \
-		echo "Please activate the correct environment with:"; \
+		echo "Error: Linting must be run using a Python virtual environment"; \
+		echo "Please activate the correct environment for example:"; \
 		echo "  source venv/bin/activate"; \
 		echo ""; \
 		exit 1; \
@@ -40,10 +40,10 @@ lint: ## Run code formatting and linting tools on source
 	pylint run.py coded_tools/
 
 lint-tests: ## Run code formatting and linting tools on tests
-	@if [ "$$(which python | grep -c "./venv")" -eq 0 ]; then \
+	@if [ -z "$$VIRTUAL_ENV" ]; then \
 		echo ""; \
-		echo "Error: Linting must be run using the ./venv Python environment"; \
-		echo "Please activate the correct environment with:"; \
+		echo "Error: Linting must be run using a Python virtual environment"; \
+		echo "Please activate the correct environment for example:"; \
 		echo "  source venv/bin/activate"; \
 		echo ""; \
 		exit 1; \

--- a/README.md
+++ b/README.md
@@ -79,18 +79,46 @@ You can get your OpenAI API key from <https://platform.openai.com/signup>. After
 
 Other providers and models are supported too but will require proper setup.
 
+---
+
 ## Run
 
 There are multiple ways in which we can now use the neuro-san server with a client:
 
-### Option 1: Using a basic web client interface
+### Option 1: Using [`nsflow`](https://github.com/leaf-ai/nsflow) as a developer-oriented web client
+
+If you want to use neuro-san with a FastAPI-based developer-oriented client, follow these steps:
+
+- Start the server and client with a single command, from project root:
+
+  ```bash
+  python -m run
+  ```
+
+- As a default
+  - Frontend will be available at: `http://127.0.0.1:4173`
+  - The client and server logs will be saved to `logs/nsflow.log` and `logs/server.log` respectively.
+
+- To see the various config options for this app, on terminal
+
+  ```bash
+  python -m run --help
+  ```
+
+Screenshot:
+
+![NSFlow UI Snapshot](https://raw.githubusercontent.com/leaf-ai/nsflow/main/docs/snapshot01.png)
+
+---
+
+### Option 2: Using a basic web client interface
 
 A [basic web client interface](https://github.com/leaf-ai/neuro-san-web-client) is installed by default.
 It's a great, simple example of how to connect to a neuro-san server and interact with it.
 Start the server and the client in one single command:
 
 ```bash
-python -m run
+python -m run --use-flask-web-client
 ```
 
 The client and server logs will show on the screen,
@@ -117,33 +145,6 @@ Run this command to see the various config options for the server and client:
 ```bash
 python -m run --help
 ```
-
----
-
-### Option 2: Using [`nsflow`](https://github.com/leaf-ai/nsflow) as a developer-oriented web client
-
-If you want to use neuro-san with a FastAPI-based developer-oriented client, follow these steps:
-
-- Start the Backend & Frontend, from project root:
-
-  ```bash
-  python -m nsflow.run
-  ```
-
-By default:
-
-- Frontend will be available at: `http://127.0.0.1:4173`
-- OpenAPI specs will be available at: `http://127.0.0.1:4173/docs`
-
-To see the various config options for this app, on terminal
-
-```bash
-python -m nsflow.run --help
-```
-
-Screenshot:
-
-![NSFlow UI Snapshot](https://raw.githubusercontent.com/leaf-ai/nsflow/main/docs/snapshot01.png)
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Neuro SAN
-neuro-san==0.5.22
+neuro-san==0.5.23
 neuro-san-web-client==0.1.10
-nsflow==0.5.9
+nsflow==0.5.10
 
 # For the airline_policy demo and agentic rag, to extract text from documents
 pypdf>=5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
 neuro-san==0.5.23
-neuro-san-web-client==0.1.10
+neuro-san-web-client==0.1.11
 nsflow==0.5.10
 
 # For the airline_policy demo and agentic rag, to extract text from documents

--- a/run.py
+++ b/run.py
@@ -14,8 +14,9 @@ import signal
 import subprocess
 import sys
 import threading
-
+import time
 from dotenv import load_dotenv
+
 
 
 # pylint: disable=too-many-instance-attributes
@@ -27,23 +28,32 @@ class NeuroSanRunner:
         self.is_windows = os.name == "nt"
 
         # Load environment variables from .env file
-        self.root_dir = os.getcwd()
+        self.root_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # self.root_dir = os.getcwd()
         print(f"Root directory: {self.root_dir}")
         self.load_env_variables()
 
         # Default Configuration
+        self.manifest_update_period_seconds = int(os.getenv("MANIFEST_UPDATE_PERIOD_SECONDS", "5"))
         self.neuro_san_server_host = os.getenv("NEURO_SAN_SERVER_HOST", "localhost")
         self.neuro_san_server_port = int(os.getenv("NEURO_SAN_SERVER_PORT", "30013"))
+        self.nsflow_port = int(os.getenv("NSFLOW_PORT", "4173"))
         self.neuro_san_web_client_port = int(os.getenv("NEURO_SAN_WEB_CLIENT_PORT", "5003"))
         thinking_file = "C:\\tmp\\agent_thinking.txt" if self.is_windows else "/tmp/agent_thinking.txt"
         self.thinking_file = os.getenv("THINKING_FILE", thinking_file)
+        self.agent_manifest_file = os.getenv("AGENT_MANIFEST_FILE",
+                                             os.path.join(self.root_dir, "registries", "manifest.hocon")),
+        self.agent_tool_path = os.getenv("AGENT_TOOL_PATH",
+                                         os.path.join(self.root_dir, "coded_tools")),
 
         # Parse command-line arguments
         self.config = self.parse_args()
 
         # Process references
         self.server_process = None
-        self.app_process = None
+        self.flask_webclient_process = None
+        self.nsflow_process = None
 
         # Ensure logs directory exists
         os.makedirs("logs", exist_ok=True)
@@ -59,7 +69,8 @@ class NeuroSanRunner:
 
     def parse_args(self):
         """Parses command-line arguments for configuration."""
-        parser = argparse.ArgumentParser(description="Run the Neuro SAN server and web client.")
+        parser = argparse.ArgumentParser(description="Run the Neuro SAN server and web client.",
+                                         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
         parser.add_argument(
             "--server-host", type=str, default=self.neuro_san_server_host, help="Host address for the Neuro SAN server"
@@ -68,28 +79,70 @@ class NeuroSanRunner:
             "--server-port", type=int, default=self.neuro_san_server_port, help="Port number for the Neuro SAN server"
         )
         parser.add_argument(
-            "--web-client-port",
-            type=int,
-            default=self.neuro_san_web_client_port,
-            help="Port number for the web client",
+            "--nsflow-port", type=int, default=self.nsflow_port, help="Port number for the nsflow client",
+        )
+        parser.add_argument(
+            "--web-client-port", type=int, default=self.neuro_san_web_client_port, help="Port number for the web client",
         )
         parser.add_argument(
             "--thinking-file", type=str, default=self.thinking_file, help="Path to the agent thinking file"
         )
         parser.add_argument("--no-html", action="store_true", help="Don't generate html for network diagrams")
+        parser.add_argument("--client-only", action="store_true",
+                            help="Run only the nsflow client without NeuroSan server")
+        parser.add_argument("--server-only", action="store_true",
+                            help="Run only the NeuroSan server without the default nsflow client")
+        parser.add_argument("--use-flask-web-client", action="store_true",
+                            help="Use the flask based neuro-san-web-client")
+        
+        args, _ = parser.parse_known_args()
+        explicitly_passed_args = {arg for arg in sys.argv[1:] if arg.startswith("--")}
+        # Check for mutually exclusive arguments
+        if args.client_only and ("--server-host" in explicitly_passed_args
+                                 or "--server-port" in explicitly_passed_args):
+            parser.error("[x] You cannot specify --server-host or --server-port "
+                         "when using --client-only mode.")
+        if args.server_only and ("--nsflow-host" in explicitly_passed_args
+                                 or "--nsflow-port" in explicitly_passed_args):
+            parser.error("[x] You cannot specify --nsflow-host or --nsflow-port "
+                         "when using --server-only mode.")
+        if args.client_only and args.server_only:
+            parser.error("[x] You cannot specify both --client-only and --server-only at the same time.")
 
-        return vars(parser.parse_args())
+        return vars(args)
 
     @staticmethod
-    def set_environment_variables():
+    def set_environment_variables(self):
         """Set required environment variables, optionally using neuro-san defaults."""
-        os.environ["PYTHONPATH"] = os.getcwd()
-        os.environ["AGENT_MANIFEST_FILE"] = "./registries/manifest.hocon"
-        os.environ["AGENT_TOOL_PATH"] = "./coded_tools"
-
+        print("\n" + "="*50 + "\n")
+        print("Setting environment variables...\n")
+        # Common env variables
+        os.environ["PYTHONPATH"] = self.root_dir
+        os.environ["AGENT_MANIFEST_FILE"] = self.agent_manifest_file
+        os.environ["AGENT_TOOL_PATH"] = self.agent_tool_path
         print(f"PYTHONPATH set to: {os.environ['PYTHONPATH']}\n")
         print(f"AGENT_MANIFEST_FILE set to: {os.environ['AGENT_MANIFEST_FILE']}")
         print(f"AGENT_TOOL_PATH set to: {os.environ['AGENT_TOOL_PATH']}\n")
+
+        # Client-only env variables
+        if self.config["client_only"]:
+            print("Running in client-only mode.")
+            if self.config["use_flask_web_client"]:
+                os.environ["NEURO_SAN_WEB_CLIENT_PORT"] = str(self.config["web_client_port"])
+                print(f"NEURO_SAN_WEB_CLIENT_PORT set to: {os.environ['NEURO_SAN_WEB_CLIENT_PORT']}")
+            else:
+                os.environ["NSFLOW_PORT"] = str(self.config["nsflow_port"])
+                print(f"NSFLOW_PORT set to: {os.environ['NSFLOW_PORT']}")
+
+        # Server-only env variables
+        if self.config["server_only"]:
+            print("Running in server-only mode.")
+            os.environ["NEURO_SAN_SERVER_HOST"] = self.config["server_host"]
+            os.environ["NEURO_SAN_SERVER_PORT"] = str(self.config["server_port"])
+            print(f"NEURO_SAN_SERVER_HOST set to: {os.environ['NEURO_SAN_SERVER_HOST']}")
+            print(f"NEURO_SAN_SERVER_PORT set to: {os.environ['NEURO_SAN_SERVER_PORT']}\n")
+        print("\n" + "="*50 + "\n")
+
 
     @staticmethod
     def generate_html_files():
@@ -147,6 +200,41 @@ class NeuroSanRunner:
         stderr_thread.start()
 
         return process
+    
+    def start_neuro_san(self):
+        """Start the Neuro SAN server."""
+        print("Starting Neuro SAN server...")
+        command = [
+            sys.executable, "-u", "-m", "neuro_san.service.agent_main_loop",
+            "--port", str(self.config["server_port"])
+        ]
+        self.server_process = self.start_process(command, "NeuroSan", "logs/server.log")
+        print("NeuroSan server started on port: ", self.config["server_port"])
+
+    def start_nsflow(self):
+        """Start FastAPI backend."""
+        print("Starting FastAPI backend...")
+        command = [
+            sys.executable, "-u", "-m", "uvicorn", "nsflow.backend.main:app",
+            "--port", str(self.config["nsflow_port"]),
+            "--reload"
+        ]
+
+        self.nsflow_process = self.start_process(command, "nsflow", "logs/nsflow.log")
+        print("nsflow client started on port: %s", self.config["nsflow_port"])
+
+    def start_flask_web_client(self):
+        """Start the Flask web client."""
+        print("Starting Flask web client...")
+        command = [
+            sys.executable, "-u", "-m", "neuro_san_web_client.app",
+            "--server-host", self.config["server_host"],
+            "--server-port", str(self.config["server_port"]),
+            "--web-client-port", str(self.config["web_client_port"]),
+            "--thinking-file", self.config["thinking_file"],
+        ]
+        self.flask_webclient_process = self.start_process(command, "FlaskWebClient", "logs/webclient.log")
+        print("Flask web client started on port: ", self.config["web_client_port"])
 
     # pylint: disable=unused-argument
     def signal_handler(self, signum, frame):
@@ -170,7 +258,7 @@ class NeuroSanRunner:
         sys.exit(0)
 
     def run(self):
-        """Run the Neuro SAN server and web client."""
+        """Run the Neuro SAN server and a client."""
         print("\nRun Config:\n" + "\n".join(f"{key}: {value}" for key, value in self.config.items()) + "\n")
 
         # Set environment variables
@@ -188,37 +276,35 @@ class NeuroSanRunner:
         if not self.is_windows:
             signal.signal(signal.SIGTERM, self.signal_handler)  # Handle kill command (not available on Windows)
 
-        # Start server (Log to logs/server.log)
-        server_command = [
-            sys.executable,
-            "-u",
-            "-m",
-            "neuro_san.service.agent_main_loop",
-            "--port",
-            str(self.config["server_port"]),
-        ]
-        self.server_process = self.start_process(server_command, "SERVER", "logs/server.log")
+        # Handle mutually exclusive modes
+        client_only = self.config["client_only"]
+        server_only = self.config["server_only"]
 
-        # Start web client (Log to logs/client.log)
-        client_command = [
-            sys.executable,
-            "-u",
-            "-m",
-            "neuro_san_web_client.app",
-            "--server-host",
-            self.config["server_host"],
-            "--server-port",
-            str(self.config["server_port"]),
-            "--web-client-port",
-            str(self.config["web_client_port"]),
-            "--thinking-file",
-            self.config["thinking_file"],
-        ]
-        self.app_process = self.start_process(client_command, "WEB CLIENT", "logs/client.log")
+        if client_only and server_only:
+            print("[x] You cannot specify both --client-only and --server-only at the same time.")
+            sys.exit(1)
 
-        # Wait for both processes to finish
-        self.server_process.wait()
-        self.app_process.wait()
+        if not server_only:
+            if self.config["use_flask_web_client"]:
+                self.start_flask_web_client()
+            else:
+                self.start_nsflow()
+
+        if not client_only:
+            self.start_neuro_san()
+            time.sleep(3)  # Give the server some time to start
+
+        print("All processes now running.")
+        print("Press Ctrl+C to stop the server.")
+        print("\n" + "="*50 + "\n")
+
+        # Wait on active processes to finish
+        if self.nsflow_process:
+            self.nsflow_process.wait()
+        if self.server_process:
+            self.server_process.wait()
+        if self.flask_webclient_process:
+            self.flask_webclient_process.wait()
 
 
 if __name__ == "__main__":

--- a/run.py
+++ b/run.py
@@ -15,8 +15,8 @@ import subprocess
 import sys
 import threading
 import time
-from dotenv import load_dotenv
 
+from dotenv import load_dotenv
 
 
 # pylint: disable=too-many-instance-attributes
@@ -42,10 +42,10 @@ class NeuroSanRunner:
         self.neuro_san_web_client_port = int(os.getenv("NEURO_SAN_WEB_CLIENT_PORT", "5003"))
         thinking_file = "C:\\tmp\\agent_thinking.txt" if self.is_windows else "/tmp/agent_thinking.txt"
         self.thinking_file = os.getenv("THINKING_FILE", thinking_file)
-        self.agent_manifest_file = os.getenv("AGENT_MANIFEST_FILE",
-                                             os.path.join(self.root_dir, "registries", "manifest.hocon")),
-        self.agent_tool_path = os.getenv("AGENT_TOOL_PATH",
-                                         os.path.join(self.root_dir, "coded_tools")),
+        self.agent_manifest_file = (
+            os.getenv("AGENT_MANIFEST_FILE", os.path.join(self.root_dir, "registries", "manifest.hocon")),
+        )
+        self.agent_tool_path = (os.getenv("AGENT_TOOL_PATH", os.path.join(self.root_dir, "coded_tools")),)
 
         # Parse command-line arguments
         self.config = self.parse_args()
@@ -69,8 +69,10 @@ class NeuroSanRunner:
 
     def parse_args(self):
         """Parses command-line arguments for configuration."""
-        parser = argparse.ArgumentParser(description="Run the Neuro SAN server and web client.",
-                                         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser = argparse.ArgumentParser(
+            description="Run the Neuro SAN server and web client.",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
 
         parser.add_argument(
             "--server-host", type=str, default=self.neuro_san_server_host, help="Host address for the Neuro SAN server"
@@ -79,42 +81,50 @@ class NeuroSanRunner:
             "--server-port", type=int, default=self.neuro_san_server_port, help="Port number for the Neuro SAN server"
         )
         parser.add_argument(
-            "--nsflow-port", type=int, default=self.nsflow_port, help="Port number for the nsflow client",
+            "--nsflow-port",
+            type=int,
+            default=self.nsflow_port,
+            help="Port number for the nsflow client",
         )
         parser.add_argument(
-            "--web-client-port", type=int, default=self.neuro_san_web_client_port, help="Port number for the web client",
+            "--web-client-port",
+            type=int,
+            default=self.neuro_san_web_client_port,
+            help="Port number for the web client",
         )
         parser.add_argument(
             "--thinking-file", type=str, default=self.thinking_file, help="Path to the agent thinking file"
         )
         parser.add_argument("--no-html", action="store_true", help="Don't generate html for network diagrams")
-        parser.add_argument("--client-only", action="store_true",
-                            help="Run only the nsflow client without NeuroSan server")
-        parser.add_argument("--server-only", action="store_true",
-                            help="Run only the NeuroSan server without the default nsflow client")
-        parser.add_argument("--use-flask-web-client", action="store_true",
-                            help="Use the flask based neuro-san-web-client")
-        
+        parser.add_argument(
+            "--client-only", action="store_true", help="Run only the nsflow client without NeuroSan server"
+        )
+        parser.add_argument(
+            "--server-only", action="store_true", help="Run only the NeuroSan server without the default nsflow client"
+        )
+        parser.add_argument(
+            "--use-flask-web-client", action="store_true", help="Use the flask based neuro-san-web-client"
+        )
+
         args, _ = parser.parse_known_args()
         explicitly_passed_args = {arg for arg in sys.argv[1:] if arg.startswith("--")}
         # Check for mutually exclusive arguments
-        if args.client_only and ("--server-host" in explicitly_passed_args
-                                 or "--server-port" in explicitly_passed_args):
-            parser.error("[x] You cannot specify --server-host or --server-port "
-                         "when using --client-only mode.")
-        if args.server_only and ("--nsflow-host" in explicitly_passed_args
-                                 or "--nsflow-port" in explicitly_passed_args):
-            parser.error("[x] You cannot specify --nsflow-host or --nsflow-port "
-                         "when using --server-only mode.")
+        if args.client_only and (
+            "--server-host" in explicitly_passed_args or "--server-port" in explicitly_passed_args
+        ):
+            parser.error("[x] You cannot specify --server-host or --server-port when using --client-only mode.")
+        if args.server_only and (
+            "--nsflow-host" in explicitly_passed_args or "--nsflow-port" in explicitly_passed_args
+        ):
+            parser.error("[x] You cannot specify --nsflow-host or --nsflow-port when using --server-only mode.")
         if args.client_only and args.server_only:
             parser.error("[x] You cannot specify both --client-only and --server-only at the same time.")
 
         return vars(args)
 
-    @staticmethod
     def set_environment_variables(self):
         """Set required environment variables, optionally using neuro-san defaults."""
-        print("\n" + "="*50 + "\n")
+        print("\n" + "=" * 50 + "\n")
         print("Setting environment variables...\n")
         # Common env variables
         os.environ["PYTHONPATH"] = self.root_dir
@@ -141,8 +151,7 @@ class NeuroSanRunner:
             os.environ["NEURO_SAN_SERVER_PORT"] = str(self.config["server_port"])
             print(f"NEURO_SAN_SERVER_HOST set to: {os.environ['NEURO_SAN_SERVER_HOST']}")
             print(f"NEURO_SAN_SERVER_PORT set to: {os.environ['NEURO_SAN_SERVER_PORT']}\n")
-        print("\n" + "="*50 + "\n")
-
+        print("\n" + "=" * 50 + "\n")
 
     @staticmethod
     def generate_html_files():
@@ -200,13 +209,17 @@ class NeuroSanRunner:
         stderr_thread.start()
 
         return process
-    
+
     def start_neuro_san(self):
         """Start the Neuro SAN server."""
         print("Starting Neuro SAN server...")
         command = [
-            sys.executable, "-u", "-m", "neuro_san.service.agent_main_loop",
-            "--port", str(self.config["server_port"])
+            sys.executable,
+            "-u",
+            "-m",
+            "neuro_san.service.agent_main_loop",
+            "--port",
+            str(self.config["server_port"]),
         ]
         self.server_process = self.start_process(command, "NeuroSan", "logs/server.log")
         print("NeuroSan server started on port: ", self.config["server_port"])
@@ -215,9 +228,14 @@ class NeuroSanRunner:
         """Start FastAPI backend."""
         print("Starting FastAPI backend...")
         command = [
-            sys.executable, "-u", "-m", "uvicorn", "nsflow.backend.main:app",
-            "--port", str(self.config["nsflow_port"]),
-            "--reload"
+            sys.executable,
+            "-u",
+            "-m",
+            "uvicorn",
+            "nsflow.backend.main:app",
+            "--port",
+            str(self.config["nsflow_port"]),
+            "--reload",
         ]
 
         self.nsflow_process = self.start_process(command, "nsflow", "logs/nsflow.log")
@@ -227,11 +245,18 @@ class NeuroSanRunner:
         """Start the Flask web client."""
         print("Starting Flask web client...")
         command = [
-            sys.executable, "-u", "-m", "neuro_san_web_client.app",
-            "--server-host", self.config["server_host"],
-            "--server-port", str(self.config["server_port"]),
-            "--web-client-port", str(self.config["web_client_port"]),
-            "--thinking-file", self.config["thinking_file"],
+            sys.executable,
+            "-u",
+            "-m",
+            "neuro_san_web_client.app",
+            "--server-host",
+            self.config["server_host"],
+            "--server-port",
+            str(self.config["server_port"]),
+            "--web-client-port",
+            str(self.config["web_client_port"]),
+            "--thinking-file",
+            self.config["thinking_file"],
         ]
         self.flask_webclient_process = self.start_process(command, "FlaskWebClient", "logs/webclient.log")
         print("Flask web client started on port: ", self.config["web_client_port"])
@@ -248,12 +273,12 @@ class NeuroSanRunner:
             else:
                 os.killpg(os.getpgid(self.server_process.pid), signal.SIGKILL)
 
-        if self.app_process:
-            print(f"Stopping WEB CLIENT (PID {self.app_process.pid})...")
+        if self.flask_webclient_process:
+            print(f"Stopping WEB CLIENT (PID {self.flask_webclient_process.pid})...")
             if self.is_windows:
-                self.app_process.terminate()
+                self.flask_webclient_process.terminate()
             else:
-                os.killpg(os.getpgid(self.app_process.pid), signal.SIGKILL)
+                os.killpg(os.getpgid(self.flask_webclient_process.pid), signal.SIGKILL)
 
         sys.exit(0)
 
@@ -296,7 +321,7 @@ class NeuroSanRunner:
 
         print("All processes now running.")
         print("Press Ctrl+C to stop the server.")
-        print("\n" + "="*50 + "\n")
+        print("\n" + "=" * 50 + "\n")
 
         # Wait on active processes to finish
         if self.nsflow_process:

--- a/run.py
+++ b/run.py
@@ -131,9 +131,9 @@ class NeuroSanRunner:
         os.environ["AGENT_MANIFEST_FILE"] = self.agent_manifest_file
         os.environ["AGENT_TOOL_PATH"] = self.agent_tool_path
         os.environ["AGENT_MANIFEST_UPDATE_PERIOD_SECONDS"] = str(self.manifest_update_period_seconds)
-        print(f"PYTHONPATH set to: {os.environ['PYTHONPATH']}\n")
+        print(f"PYTHONPATH set to: {os.environ['PYTHONPATH']}")
         print(f"AGENT_MANIFEST_FILE set to: {os.environ['AGENT_MANIFEST_FILE']}")
-        print(f"AGENT_TOOL_PATH set to: {os.environ['AGENT_TOOL_PATH']}\n")
+        print(f"AGENT_TOOL_PATH set to: {os.environ['AGENT_TOOL_PATH']}")
         print(f"AGENT_MANIFEST_UPDATE_PERIOD_SECONDS set to: {os.environ['AGENT_MANIFEST_UPDATE_PERIOD_SECONDS']}\n")
 
         # Client-only env variables

--- a/run.py
+++ b/run.py
@@ -135,28 +135,24 @@ class NeuroSanRunner:
         print(f"AGENT_TOOL_PATH set to: {os.environ['AGENT_TOOL_PATH']}\n")
 
         # Client-only env variables
-        if self.config["client_only"]:
-            print("Running in client-only mode.")
-            if self.config["use_flask_web_client"]:
-                os.environ["NEURO_SAN_WEB_CLIENT_PORT"] = str(self.config["web_client_port"])
-                print(f"NEURO_SAN_WEB_CLIENT_PORT set to: {os.environ['NEURO_SAN_WEB_CLIENT_PORT']}")
-            else:
-                os.environ["NSFLOW_PORT"] = str(self.config["nsflow_port"])
-                print(f"NSFLOW_PORT set to: {os.environ['NSFLOW_PORT']}")
+        if self.config["use_flask_web_client"]:
+            os.environ["NEURO_SAN_WEB_CLIENT_PORT"] = str(self.config["web_client_port"])
+            print(f"NEURO_SAN_WEB_CLIENT_PORT set to: {os.environ['NEURO_SAN_WEB_CLIENT_PORT']}")
+        else:
+            os.environ["NSFLOW_PORT"] = str(self.config["nsflow_port"])
+            print(f"NSFLOW_PORT set to: {os.environ['NSFLOW_PORT']}")
 
         # Server-only env variables
-        if self.config["server_only"]:
-            print("Running in server-only mode.")
-            os.environ["NEURO_SAN_SERVER_HOST"] = self.config["server_host"]
-            os.environ["NEURO_SAN_SERVER_PORT"] = str(self.config["server_port"])
+        os.environ["NEURO_SAN_SERVER_HOST"] = self.config["server_host"]
+        os.environ["NEURO_SAN_SERVER_PORT"] = str(self.config["server_port"])
 
-            # Adding these two below only because of different naming in nsflow client
-            # These should be removed when the nsflow client is updated to use consistent environment variable names
-            os.environ["NS_SERVER_HOST"] = self.config["server_host"]
-            os.environ["NS_SERVER_PORT"] = str(self.config["server_port"])
+        # Adding these two below only because nsflow depends on these variables that are named differently
+        # These should be removed when the nsflow client is updated to use consistent environment variable names
+        os.environ["NS_SERVER_HOST"] = self.config["server_host"]
+        os.environ["NS_SERVER_PORT"] = str(self.config["server_port"])
 
-            print(f"NEURO_SAN_SERVER_HOST set to: {os.environ['NEURO_SAN_SERVER_HOST']}")
-            print(f"NEURO_SAN_SERVER_PORT set to: {os.environ['NEURO_SAN_SERVER_PORT']}\n")
+        print(f"NEURO_SAN_SERVER_HOST set to: {os.environ['NEURO_SAN_SERVER_HOST']}")
+        print(f"NEURO_SAN_SERVER_PORT set to: {os.environ['NEURO_SAN_SERVER_PORT']}\n")
         print("\n" + "=" * 50 + "\n")
 
     @staticmethod
@@ -231,8 +227,8 @@ class NeuroSanRunner:
         print("NeuroSan server started on port: ", self.config["server_port"])
 
     def start_nsflow(self):
-        """Start FastAPI backend."""
-        print("Starting FastAPI backend...")
+        """Start nsflow client."""
+        print("Starting nsflow slient...")
         command = [
             sys.executable,
             "-u",
@@ -245,7 +241,7 @@ class NeuroSanRunner:
         ]
 
         self.nsflow_process = self.start_process(command, "nsflow", "logs/nsflow.log")
-        print("nsflow client started on port: %s", self.config["nsflow_port"])
+        print("nsflow client started on port: ", self.config["nsflow_port"])
 
     def start_flask_web_client(self):
         """Start the Flask web client."""

--- a/run.py
+++ b/run.py
@@ -135,24 +135,31 @@ class NeuroSanRunner:
         print(f"AGENT_TOOL_PATH set to: {os.environ['AGENT_TOOL_PATH']}\n")
 
         # Client-only env variables
-        if self.config["use_flask_web_client"]:
-            os.environ["NEURO_SAN_WEB_CLIENT_PORT"] = str(self.config["web_client_port"])
-            print(f"NEURO_SAN_WEB_CLIENT_PORT set to: {os.environ['NEURO_SAN_WEB_CLIENT_PORT']}")
-        else:
-            os.environ["NSFLOW_PORT"] = str(self.config["nsflow_port"])
-            print(f"NSFLOW_PORT set to: {os.environ['NSFLOW_PORT']}")
+        if not self.config["server_only"]:
+            if self.config["use_flask_web_client"]:
+                os.environ["NEURO_SAN_WEB_CLIENT_PORT"] = str(self.config["web_client_port"])
+                print(f"NEURO_SAN_WEB_CLIENT_PORT set to: {os.environ['NEURO_SAN_WEB_CLIENT_PORT']}")
+            else:
+                os.environ["NSFLOW_PORT"] = str(self.config["nsflow_port"])
+                print(f"NSFLOW_PORT set to: {os.environ['NSFLOW_PORT']}")
+                # Set env variable for using nsflow in client-only mode
+                if self.config["client_only"]:
+                    os.environ["NSFLOW_CLIENT_ONLY"] = "True"
+                    print(f"NSFLOW_CLIENT_ONLY set to: {os.environ['NSFLOW_CLIENT_ONLY']}")
 
         # Server-only env variables
-        os.environ["NEURO_SAN_SERVER_HOST"] = self.config["server_host"]
-        os.environ["NEURO_SAN_SERVER_PORT"] = str(self.config["server_port"])
+        if not self.config["client_only"]:
+            os.environ["NEURO_SAN_SERVER_HOST"] = self.config["server_host"]
+            os.environ["NEURO_SAN_SERVER_PORT"] = str(self.config["server_port"])
 
-        # Adding these two below only because nsflow depends on these variables that are named differently
-        # These should be removed when the nsflow client is updated to use consistent environment variable names
-        os.environ["NS_SERVER_HOST"] = self.config["server_host"]
-        os.environ["NS_SERVER_PORT"] = str(self.config["server_port"])
+            # Adding these two below only because nsflow depends on these variables that are named differently
+            # These should be removed when the nsflow client is updated to use consistent environment variable names
+            os.environ["NS_SERVER_HOST"] = self.config["server_host"]
+            os.environ["NS_SERVER_PORT"] = str(self.config["server_port"])
 
-        print(f"NEURO_SAN_SERVER_HOST set to: {os.environ['NEURO_SAN_SERVER_HOST']}")
-        print(f"NEURO_SAN_SERVER_PORT set to: {os.environ['NEURO_SAN_SERVER_PORT']}\n")
+            print(f"NEURO_SAN_SERVER_HOST set to: {os.environ['NEURO_SAN_SERVER_HOST']}")
+            print(f"NEURO_SAN_SERVER_PORT set to: {os.environ['NEURO_SAN_SERVER_PORT']}\n")
+
         print("\n" + "=" * 50 + "\n")
 
     @staticmethod

--- a/run.py
+++ b/run.py
@@ -35,7 +35,7 @@ class NeuroSanRunner:
         self.load_env_variables()
 
         # Default Configuration
-        self.manifest_update_period_seconds = int(os.getenv("MANIFEST_UPDATE_PERIOD_SECONDS", "5"))
+        self.manifest_update_period_seconds = int(os.getenv("AGENT_MANIFEST_UPDATE_PERIOD_SECONDS", "5"))
         self.neuro_san_server_host = os.getenv("NEURO_SAN_SERVER_HOST", "localhost")
         self.neuro_san_server_port = int(os.getenv("NEURO_SAN_SERVER_PORT", "30013"))
         self.nsflow_port = int(os.getenv("NSFLOW_PORT", "4173"))
@@ -130,9 +130,11 @@ class NeuroSanRunner:
         os.environ["PYTHONPATH"] = self.root_dir
         os.environ["AGENT_MANIFEST_FILE"] = self.agent_manifest_file
         os.environ["AGENT_TOOL_PATH"] = self.agent_tool_path
+        os.environ["AGENT_MANIFEST_UPDATE_PERIOD_SECONDS"] = str(self.manifest_update_period_seconds)
         print(f"PYTHONPATH set to: {os.environ['PYTHONPATH']}\n")
         print(f"AGENT_MANIFEST_FILE set to: {os.environ['AGENT_MANIFEST_FILE']}")
         print(f"AGENT_TOOL_PATH set to: {os.environ['AGENT_TOOL_PATH']}\n")
+        print(f"AGENT_MANIFEST_UPDATE_PERIOD_SECONDS set to: {os.environ['AGENT_MANIFEST_UPDATE_PERIOD_SECONDS']}\n")
 
         # Client-only env variables
         if not self.config["server_only"]:


### PR DESCRIPTION
Changes:
- Use `nsflow` as the default client in `neuro-san-demos`
- Add option to use `flask-web-client`
- Add option to run neuro-san-demos in `client-only` and `server-only` mode
- Add env variable `AGENT_MANIFEST_UPDATE_PERIOD_SECONDS` that updates the manifest at a given interval
- Update makefile to work with any python `VIRTUAL_ENV`
- Reorder sections in `README.md`