### PR TITLE
Add smart_home_include.hocon as an example to how to import hocon file

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -48,18 +48,19 @@ HOCON supports value substitution by referencing previously defined configuratio
 
 To substitute a value, wrap the referenced key in `${}`:
 ```json
-function = ${aaosa_call}
+"function": ${aaosa_call}
 ```
 
 To substitute a nested value inside an object or dictionary, use dot notation:
 ```json
-name = ${info.name}
+"name": ${info.name}
 ```
 
 Note that substitutions are **not parsed inside quoted strings**. If you need to include a substitution within a string, you can quote only the non-substituted parts:
 ```json
-instructions = ${insturction_prefix} "main instruction" ${instruction_suffix}
+"instructions": ${insturction_prefix} "main instruction" ${instruction_suffix}
 ```
+You can see a working example [here](../registries/smart_home_include.hocon).
 
 For more details, please see [https://github.com/lightbend/config/blob/main/HOCON.md#substitutions](https://github.com/lightbend/config/blob/main/HOCON.md#substitutions)
 

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -17,6 +17,7 @@
     "advanced_calculator.hocon": true,
     "smart_home.hocon": true,
     "smart_home_onf.hocon": true,
+    "smart_home_include.hocon": true,
     "agent_network_designer.hocon": true,
     "agent_network_generator.hocon" : true,
     "music_nerd.hocon": true,

--- a/registries/smart_home_include.hocon
+++ b/registries/smart_home_include.hocon
@@ -9,7 +9,9 @@
 #
 {
     # Importing content from other HOCON files
-    # Keyword include has to be unquoted and has to be followed by quoted string which is either url or file path.
+    # The include keyword must be unquoted and followed by a quoted URL or file path.
+    # File paths should be absolute or relative to the script's working directory, not the HOCON file location.
+
     # The below file contains keys-values for substitution with the following keys;
     # aaosa_call, aaosa_command, and aaosa_instructions
     include "https://raw.githubusercontent.com/leaf-ai/neuro-san-demos/main/registries/aaosa.hocon"

--- a/registries/smart_home_include.hocon
+++ b/registries/smart_home_include.hocon
@@ -1,0 +1,169 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san-demos SDK Software in commercial settings.
+#
+{
+    # Importing content from other HOCON files
+    # Keyword include has to be unquoted and has to be followed by quoted string which is either url or file path.
+    # The below file contains keys-values for substitution with the following keys;
+    # aaosa_call, aaosa_command, and aaosa_instructions
+    include "https://raw.githubusercontent.com/leaf-ai/neuro-san-demos/main/registries/aaosa.hocon"
+
+    # A key-value for substitution can also be defined inside the hocon file.
+    "instructions_prefix": """
+You are part of a smart home network of assistants.
+Only answer inquiries that are directly within your area of expertise.
+Do not try to help for other matters.
+Do not mention what you can NOT do. Only mention what you can do.
+""",
+
+    "llm_config": {
+        "model_name": "gpt-4o",
+    },
+
+    "tools": [
+        {
+            "name": "SmartHouseAssistant",
+
+            # Note that there are no parameters defined for this guy's "function" key.
+            # This is the primary way to identify this tool as a front-man,
+            # distinguishing it from the rest of the tools.
+
+            "function": {
+
+                # When there are no function parameters to the front-man,
+                # its description acts as an initial prompt. 
+
+                "description": """
+An assistant that answer inquiries from the user.
+                """
+            },
+            # Substitution uses ${key} and does not work inside quoted strings.
+            # Values next to quoted strings are automatically concatenated.
+            "instructions": ${instructions_prefix} """
+            Your name is SmartHouseAssistant. Answer inquiries related to the smart home.
+            """ ${aaosa_instructions},
+            "tools": ["TV", "Lights", "Book", "Radio"]
+        },
+        {
+            "name": "TV",
+            "function": ${aaosa_call},
+            "instructions": ${instructions_prefix} """
+Your name is TV. You can turn the TV on or off by calling your tools.
+""" ${aaosa_instructions},
+            "command": ${aaosa_command},
+            "tools": ["TV_Switch_API"]
+        },
+        {
+            "name": "Lights",
+            "function": ${aaosa_call},
+            "instructions": ${instructions_prefix} """
+Your name is Lights. You can turn lights on or off.
+""" ${aaosa_instructions},
+            "command": ${aaosa_command}
+            "tools": ["LivingRoomLights", "KitchenLights"]
+        },
+        {
+            "name": "Book",
+            "function": ${aaosa_call},
+            "instructions": ${instructions_prefix} """
+Your name is Book. You can't do anything. You're a book.
+""" ${aaosa_instructions},
+            "command": ${aaosa_command}
+        },
+        {
+            "name": "Radio",
+            "function": ${aaosa_call},
+            "instructions": ${instructions_prefix} """
+Your name is Radio. You can turn the radio on or off.
+""" ${aaosa_instructions},
+            "command": ${aaosa_command}
+        },
+        {
+            "name": "LivingRoomLights",
+            "function": ${aaosa_call},
+            "instructions": ${instructions_prefix} """
+Your name is LivingRoomLights. You can turn the lights on or off in the living room. 
+""" ${aaosa_instructions},
+            "command": ${aaosa_command},
+            "tools": ["LivingRoom_Switch_API"]
+        },
+        {
+            "name": "KitchenLights",
+            "function": ${aaosa_call},
+            "instructions": ${instructions_prefix} """
+Your name is KitchenLights. You can turn the lights on or off in the kitchen.
+""" ${aaosa_instructions},
+            "command": ${aaosa_command},
+            "tools": ["Kitchen_Switch_API"]
+        },
+        {
+            "name": "TV_Switch_API",
+            "function": {
+                "description": """
+Your name is TV_Switch
+You are an API that turns the TV ON or OFF.
+                """,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "desired_status": {
+                            "type": "string",
+                            "description": "ON to turn the tv on, OFF to turn it off."
+                        },
+                    },
+                    "required": ["desired_status"]
+                }
+            },
+            "class": "tv_switch.TVSwitch",
+            "command": "Call the API to turn the TV on or off"
+        },
+        {
+            "name": "Kitchen_Switch_API",
+            "function": {
+                "description": """
+Your name is Kitchen_Switch_API
+You are an API that turns the kitchen lights ON or OFF.
+                """,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "desired_status": {
+                            "type": "string",
+                            "description": "ON to turn the kitchen lights on, OFF to turn them off."
+                        },
+                    },
+                    "required": ["desired_status"]
+                }
+            },
+            "class": "kitchen_lights_switch.KitchenLightsSwitch",
+            "command": "Call the API to turn the kitchen lights on or off"
+        },
+        {
+            "name": "LivingRoom_Switch_API",
+            "function": {
+                "description": """
+Your name is LivingRoom_Switch_API
+You are an API that turns the living room lights ON or OFF.
+                """,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "desired_status": {
+                            "type": "string",
+                            "description": "ON to turn the living room lights on, OFF to turn them off."
+                        },
+                    },
+                    "required": ["desired_status"]
+                }
+            },
+            "class": "living_room_lights_switch.LivingRoomLightsSwitch",
+            "command": "Call the API to turn the living room lights on or off"
+        },
+    ]
+}


### PR DESCRIPTION
- Add smart_home_include.hocon and turn it on in manifest
- Point to the above hocon as example in user_guide.md