### PR TITLE
Deploy neuro-san-demos agent networks instead of those from neuro-san

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -98,17 +98,13 @@ COPY ./coded_tool[s] ${APP_SOURCE}/coded_tools
 USER ${USERNAME}
 WORKDIR ${APP_SOURCE}
 
-# RUN echo "$(pip show neuro-san | grep Location | awk '{print $2}')"
-# This value below comes from the above RUN command. Cannot set ENV vars in Dockerfiles based on shell output.
-ENV PACKAGE_INSTALL=/usr/local/lib/python3.12/site-packages
-ENV PACKAGE_DEPLOY=${PACKAGE_INSTALL}/neuro_san/deploy
-ENV APP_ENTRYPOINT=${PACKAGE_DEPLOY}/entrypoint.sh
+ENV APP_ENTRYPOINT=${APP_SOURCE}/deploy/entrypoint.sh
 
 #
 # Server configuration
 #
 
-# Run as a neuro-san only server to server 'default' demo agents (registries and coded_tools)
+# Point to the root folder of the app
 ENV PYTHONPATH=${APP_SOURCE}
 
 # Where to find the tool registry manifest file which lists all the agent hocon
@@ -127,7 +123,7 @@ ENV AGENT_TOOL_PATH=${APP_SOURCE}/coded_tools
 # See https://docs.python.org/3/library/logging.config.html#dictionary-schema-details
 # as to how this file can be configured for your own needs.  Examples there are provided in YAML,
 # but these can be easily translated to JSON (which we prefer).
-ENV AGENT_SERVICE_LOG_JSON=${PACKAGE_DEPLOY}/logging.json
+ENV AGENT_SERVICE_LOG_JSON=${APP_SOURCE}/deploy/logging.json
 
 # Threshold for logging.
 # See https://docs.python.org/3/library/logging.html#logging.Handler.setLevel
@@ -167,4 +163,3 @@ ENV AGENT_REQUEST_LIMIT=1000000
 
 # ENTRYPOINT ls ${APP_SOURCE}
 ENTRYPOINT "${APP_ENTRYPOINT}"
-

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -93,11 +93,16 @@ COPY --from=builder /install /usr/local
 #       The coded_tools directory where agent code lives is optional
 COPY ./registries ${APP_SOURCE}/registries
 COPY ./coded_tool[s] ${APP_SOURCE}/coded_tools
+COPY ./deploy/entrypoint.sh ${APP_SOURCE}/deploy/entrypoint.sh
+COPY ./deploy/logging.json ${APP_SOURCE}/deploy/logging.json
 
 # Set up the entry point for when the container is run
 USER ${USERNAME}
 WORKDIR ${APP_SOURCE}
 
+# RUN echo "$(pip show neuro-san | grep Location | awk '{print $2}')"
+# This value below comes from the above RUN command. Cannot set ENV vars in Dockerfiles based on shell output.
+ENV PACKAGE_INSTALL=/usr/local/lib/python3.12/site-packages
 ENV APP_ENTRYPOINT=${APP_SOURCE}/deploy/entrypoint.sh
 
 #

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -109,11 +109,11 @@ ENV APP_ENTRYPOINT=${PACKAGE_DEPLOY}/entrypoint.sh
 #
 
 # Run as a neuro-san only server to server 'default' demo agents (registries and coded_tools)
-ENV PYTHONPATH=${PACKAGE_INSTALL}
+ENV PYTHONPATH=${APP_SOURCE}
 
 # Where to find the tool registry manifest file which lists all the agent hocon
 # files to serve up from this server instance.
-ENV AGENT_MANIFEST_FILE=${PACKAGE_INSTALL}/neuro_san/registries/manifest.hocon
+ENV AGENT_MANIFEST_FILE=${APP_SOURCE}/registries/manifest.hocon
 
 # An llm_info hocon file with user-provided llm descriptions that are to be used
 # in addition to the neuro-san defaults.
@@ -121,7 +121,7 @@ ENV AGENT_LLM_INFO_FILE=""
 
 # Where to find the classes for CodedTool class implementations
 # that are used by specific agent networks.
-ENV AGENT_TOOL_PATH=${PACKAGE_INSTALL}/neuro_san/coded_tools
+ENV AGENT_TOOL_PATH=${APP_SOURCE}/coded_tools
 
 # Where to find the configuration file for Python logging.
 # See https://docs.python.org/3/library/logging.config.html#dictionary-schema-details

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -20,7 +20,7 @@
 #
 
 export SERVICE_TAG=${SERVICE_TAG:-neuro-san-demos}
-export SERVICE_VERSION=${SERVICE_VERSION:-0.0.8}
+export SERVICE_VERSION=${SERVICE_VERSION:-0.0.9}
 
 function check_directory() {
     working_dir=$(pwd)

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -20,7 +20,7 @@
 #
 
 export SERVICE_TAG=${SERVICE_TAG:-neuro-san-demos}
-export SERVICE_VERSION=${SERVICE_VERSION:-0.0.7}
+export SERVICE_VERSION=${SERVICE_VERSION:-0.0.8}
 
 function check_directory() {
     working_dir=$(pwd)

--- a/deploy/logging.json
+++ b/deploy/logging.json
@@ -1,0 +1,57 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "structured": {
+            "format": "{\"message\": \"%(message)s\", \"user_id\": \"%(user_id)s\", \"Timestamp\": \"%(iso_timestamp)s\", \"source\": \"%(source)s\", \"message_type\": \"%(message_type)s\", \"request_id\": \"%(request_id)s\"}"
+        }
+    },
+    "filters": {
+        "inject_context": {
+            "()": "neuro_san.http_sidecar.logging.log_context_filter.LogContextFilter"
+        }
+    },
+
+
+    "handlers": {
+        "null": {
+            "class": "logging.NullHandler",
+            "level": "INFO"
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+            "formatter": "structured",
+            "stream": "ext://sys.stdout"
+        },
+        "http_console": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+            "formatter": "structured",
+            "filters": ["inject_context"],
+            "stream": "ext://sys.stdout"
+        }
+    },
+    "loggers": {
+        "HttpServer": {
+            "level": "INFO",
+            "handlers": [
+                "http_console"
+            ],
+            "propagate": false
+        },
+        "my_module": {
+            "level": "INFO",
+            "handlers": [
+                "console"
+            ],
+            "propagate": "no"
+        }
+    },
+    "root": {
+        "level": "INFO",
+        "handlers": [
+            "console"
+        ]
+    }
+}


### PR DESCRIPTION
We were deploying the demos that were coming with the `neuro-san` library. Now that we've consolidated them into `neuro-san-demo` we need to deploy the `neuro-san-demos` one instead.