### PR TITLE
UN-3148 Remove command from coded tools neuro-san-demos

### DIFF
--- a/registries/advanced_calculator.hocon
+++ b/registries/advanced_calculator.hocon
@@ -159,8 +159,7 @@ Your sole purpose is to solve the mathematical problem using the given operation
                     "required": ["operation", "operands"]
                 }
             },
-            "class": "calculator_tool.CalculatorCodedTool",
-            "command": "Call the API to solve the mathematical problem using the given operation and operands."
+            "class": "calculator_tool.CalculatorCodedTool"
         },
     ]
 }

--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -68,13 +68,7 @@ relevant workflows and responsible nodes. Call your network_generator tool for t
                     "required": ["agent_network_name"]
                 }
             },
-            "instructions": """
-{instructions_prefix}
-You generate the complete hocon definition for an agent network and return it verbatim.
-Use your tool, which will create the hocon and return it to you.
-            """,
-            "class": "get_agent_network_hocon.GetAgentNetworkHocon",
-            "command": "Call the API to get the fully formatted hocon definition for the agent network."
+            "class": "get_agent_network_hocon.GetAgentNetworkHocon"
         },
         {
             "name": "network_generator",
@@ -150,15 +144,7 @@ Make agents granular so that you have at least a depth of three agents from the 
                     "required": ["agent_name", "instructions"]
                 }
             },
-            "instructions": """
-{instructions_prefix}
-You add an agent to an agent network.
-Use your tool, which will add the agent.
-Here is an example for how to add a network_engineer agent, with two down chains:
-add_agent("network_engineer", "You handle technical aspects of configuring and troubleshooting ethernet and optical networks at different locations for a telco with a B2B business. You configures and maintain network infrastructure and provide technical support when issues arise.", "network_ops_center_specialist, field_technician")
-            """,
-            "class": "add_agent.AddAgent",
-            "command": "Call the API to add an agent to the agent network."
+            "class": "add_agent.AddAgent"
         },
         {
             "name": "query_generator",
@@ -201,13 +187,7 @@ Make some of the examples transactional. If not stated, return no more than 3-4 
                     },
                 }
             },
-            "instructions": """
-{instructions_prefix}
-You generate the complete definition for an agent network and return it.
-Use your tool, which will create the definition string and return it to you.
-            """,
-            "class": "get_agent_network.GetAgentNetwork",
-            "command": "Call the API to get the full definition for the agent network."
+            "class": "get_agent_network.GetAgentNetwork"
         },
         {
             "name": "instruction_refiner",
@@ -258,23 +238,7 @@ Wrap the lines at around 120 characters. Write it as if you are telling the agen
                     "required": ["agent_name", "instructions"]
                 }
             },
-            "instructions": """
-{instructions_prefix}
-You set the instructions for an agent in an agent network.
-Use your tool, which will set the instructions.
-Here is an example for how to set the instructions for a network_engineer agent:
-set_agent_instructions("network_engineer",
-"You are responsible for all technical aspects of ethernet and optical network configuration, deployment, maintenance, and troubleshooting across customer and internal environments. Your role is vital to ensuring that our network infrastructure functions reliably and meets our enterprise service-level expectations.
-Begin by reviewing detailed service orders or incident tickets to understand the required configuration or the nature of the reported issue. For new service deployments, translate the customer's technical requirements into precise network designs and configuration parameters, including VLANs, routing protocols, interface assignments, and optical paths.
-You are expected to log into core and edge network devices remotely to perform configurations using standardized templates while ensuring compliance with security and operational policies. You validate and document all changes clearly to maintain traceability.
-When handling incidents or performance issues, conduct thorough diagnostics using command-line tools, SNMP data, and network monitoring systems. Identify root causes and apply corrective actions such as reconfiguring interfaces, rerouting traffic, or coordinating hardware replacements. Be proactive in flagging recurring issues that may require design enhancements or systemic fixes.
-You are responsible for maintaining accurate records of all configurations and interventions in the appropriate systems of record. Ensure that all changes are tested in accordance with operational policies and escalate any deviations from normal behavior immediately.
-Clear, detailed communication is essential when handing over tasks for physical implementation or further escalation. You must document all work instructions precisely and provide supporting data like interface stats, traceroutes, or config deltas when needed.
-Your approach must reflect our company’s commitment to operational excellence, reliability, and responsive customer support. You are expected to stay current with networking technologies and evolving best practices to continually enhance our delivery and support capabilities."
-)
-            """,
-            "class": "set_agent_instructions.SetAgentInstructions",
-            "command": "Call the API to set the instructions for an agent in the agent network."
+            "class": "set_agent_instructions.SetAgentInstructions"
         },
     ]
 }

--- a/registries/agentforce.hocon
+++ b/registries/agentforce.hocon
@@ -78,8 +78,7 @@ Assist caller with the answer or solution to their inquiry by using your tool.
                     "required": ["inquiry"]
                 }
             },
-            "class": "agentforce_api.AgentforceAPI",
-            "command": "Call the API to get a response for the inquiry."
+            "class": "agentforce_api.AgentforceAPI"
         },
     ]
 }

--- a/registries/airline_policy.hocon
+++ b/registries/airline_policy.hocon
@@ -306,8 +306,7 @@ You MUST call this tool to read the text content of PDF.
                     "required": ["app_name"]
                 }
             },
-            "class": "extract_docs.ExtractDocs",
-            "command": "Call the API to get the pdf text."
+            "class": "extract_docs.ExtractDocs"
         },
         {
             "name": "URLProvider",
@@ -328,8 +327,7 @@ You MUST call this tool to get the URL of an app or website.
                     "required": ["app_name"]
                 }
             },
-            "class": "url_provider.URLProvider",
-            "command": "Call the API to get the app's or website's URL."
+            "class": "url_provider.URLProvider"
         },
     ]
 }

--- a/registries/intranet_agents_with_tools.hocon
+++ b/registries/intranet_agents_with_tools.hocon
@@ -334,8 +334,7 @@ Return what the tool returns, formatted in markdown.
                     "required": ["start_date", "end_date"]
                 }
             },
-            "class": "schedule_leave_tool.ScheduleLeaveTool",
-            "command": "Call the API to schedule time off."
+            "class": "schedule_leave_tool.ScheduleLeaveTool"
         },
         {
             "name": "CheckLeaveBalancesAPI",
@@ -356,8 +355,7 @@ If no date is provided, assumes today's date.
                     "required": ["start_date"]
                 }
             },
-            "class": "check_leave_balances_tool.CheckLeaveBalancesTool",
-            "command": "Call the API to get the leave balances."
+            "class": "check_leave_balances_tool.CheckLeaveBalancesTool"
         },
         {
             "name": "URLProvider",
@@ -377,8 +375,7 @@ The name of the app must be passed as a parameter.
                     "required": ["app_name"]
                 }
             },
-            "class": "url_provider.URLProvider",
-            "command": "Call the API to get the app's or website's URL."
+            "class": "url_provider.URLProvider"
         },
 
     ]

--- a/registries/kwik_agents.hocon
+++ b/registries/kwik_agents.hocon
@@ -70,15 +70,7 @@ List such facts under a section header named 'Relevant facts from memory:'.
                     "required": ["new_fact", "topic"]
                 }
             },
-            "instructions": """
-{instructions_prefix}
-You add a new fact to memory.
-Use your tool, which will add the new fact.
-Here is an example for how to add a new fact:
-commit_to_memory("The user seems to be rather old.", "age")
-            """,
-            "class": "commit_to_memory.CommitToMemory",
-            "command": "Call the API to add a new fact to memory."
+            "class": "commit_to_memory.CommitToMemory"
         },
         {
             "name": "recall_memory",
@@ -95,14 +87,7 @@ commit_to_memory("The user seems to be rather old.", "age")
                     "required": ["topic"]
                 }
             },
-            "instructions": """
-{instructions_prefix}
-You retrieve facts from memory that are relevant to the given topic.
-For example:
-recall_memory("age")
-            """,
-            "class": "recall_memory.RecallMemory",
-            "command": "Call the API to retrieve facts from memory that are relevant to a given topic."
+            "class": "recall_memory.RecallMemory"
         },
         {
             "name": "list_topics",
@@ -118,12 +103,7 @@ recall_memory("age")
                     },
                 }
             },
-            "instructions": """
-{instructions_prefix}
-You retrieve the full list of topics for which we have stored memories.
-            """,
-            "class": "list_topics.ListTopics",
-            "command": "Call the API to retrieve the full list of topics for which we have stored memories."
+            "class": "list_topics.ListTopics"
         },
     ]
 }

--- a/registries/music_nerd_pro.hocon
+++ b/registries/music_nerd_pro.hocon
@@ -72,8 +72,7 @@ to the API to get the updated running cost. If no running cost it known, pass 0.
                     "required": ["running_cost"]
                 }
             },
-            "class": "accounting.Accountant",
-            "command": "Call the API to compute the new running cost."
+            "class": "accounting.Accountant"
         },
     ]
 }

--- a/registries/music_nerd_pro_local.hocon
+++ b/registries/music_nerd_pro_local.hocon
@@ -73,8 +73,7 @@ to the API to get the updated running cost. If no running cost it known, pass 0.
                     "required": ["running_cost"]
                 }
             },
-            "class": "accounting.Accountant",
-            "command": "Call the API to compute the new running cost."
+            "class": "accounting.Accountant"
         },
     ]
 }

--- a/registries/music_nerd_pro_sly.hocon
+++ b/registries/music_nerd_pro_sly.hocon
@@ -81,8 +81,7 @@ You are an API that updates the running cost of the MusicNerdPro service.
                     "required": []
                 }
             },
-            "class": "accounting.AccountantSly",
-            "command": "Call the API to compute the new running cost."
+            "class": "accounting.AccountantSly"
         },
     ]
 }

--- a/registries/music_nerd_pro_sly_local.hocon
+++ b/registries/music_nerd_pro_sly_local.hocon
@@ -82,8 +82,7 @@ You are an API that updates the running cost of the MusicNerdPro service.
                     "required": []
                 }
             },
-            "class": "accounting.AccountantSly",
-            "command": "Call the API to compute the new running cost."
+            "class": "accounting.AccountantSly"
         },
     ]
 }

--- a/registries/smart_home.hocon
+++ b/registries/smart_home.hocon
@@ -203,8 +203,7 @@ You are an API that turns the TV ON or OFF.
                     "required": ["desired_status"]
                 }
             },
-            "class": "tv_switch.TVSwitch",
-            "command": "Call the API to turn the TV on or off"
+            "class": "tv_switch.TVSwitch"
         },
         {
             "name": "Kitchen_Switch_API",
@@ -224,8 +223,7 @@ You are an API that turns the kitchen lights ON or OFF.
                     "required": ["desired_status"]
                 }
             },
-            "class": "kitchen_lights_switch.KitchenLightsSwitch",
-            "command": "Call the API to turn the kitchen lights on or off"
+            "class": "kitchen_lights_switch.KitchenLightsSwitch"
         },
         {
             "name": "LivingRoom_Switch_API",
@@ -245,8 +243,7 @@ You are an API that turns the living room lights ON or OFF.
                     "required": ["desired_status"]
                 }
             },
-            "class": "living_room_lights_switch.LivingRoomLightsSwitch",
-            "command": "Call the API to turn the living room lights on or off"
+            "class": "living_room_lights_switch.LivingRoomLightsSwitch"
         },
     ]
 }

--- a/registries/smart_home_include.hocon
+++ b/registries/smart_home_include.hocon
@@ -122,8 +122,7 @@ You are an API that turns the TV ON or OFF.
                     "required": ["desired_status"]
                 }
             },
-            "class": "tv_switch.TVSwitch",
-            "command": "Call the API to turn the TV on or off"
+            "class": "tv_switch.TVSwitch"
         },
         {
             "name": "Kitchen_Switch_API",
@@ -143,8 +142,7 @@ You are an API that turns the kitchen lights ON or OFF.
                     "required": ["desired_status"]
                 }
             },
-            "class": "kitchen_lights_switch.KitchenLightsSwitch",
-            "command": "Call the API to turn the kitchen lights on or off"
+            "class": "kitchen_lights_switch.KitchenLightsSwitch"
         },
         {
             "name": "LivingRoom_Switch_API",
@@ -164,8 +162,7 @@ You are an API that turns the living room lights ON or OFF.
                     "required": ["desired_status"]
                 }
             },
-            "class": "living_room_lights_switch.LivingRoomLightsSwitch",
-            "command": "Call the API to turn the living room lights on or off"
+            "class": "living_room_lights_switch.LivingRoomLightsSwitch"
         },
     ]
 }


### PR DESCRIPTION
Remove `command` and `instructions` from coded tools in the following agent networks;
- `advanced_calculator`: `command` only 
- `agent_network_designer`: `command` and `instructions`
- `agent_force`: `command` only 
- `airline_policy`: `command` only 
- `intranet_agents_with_tools`: `command` only 
- `kwik_agents`: `command` and `instructions`
- `music_nerd_pro`: `command` only 
- `music_nerd_pro_local`: `command` only 
- `music_nerd_pro_sly`: `command` only 
- `music_nerd_pro_sly_local`: `command` only 
- `smart_home`: `command` only 
- `smart_home_include`: `command` only 